### PR TITLE
feat: add landing page skeleton

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+import { useEffect, useState } from 'react';
+import BubbleChart from '../components/BubbleChart';
+import DataTable from '../components/DataTable';
+import AddModelForm from '../components/AddModelForm';
+import { LLMRecord } from '../lib/types';
+
+export default function Page() {
+  const [data, setData] = useState<LLMRecord[]>([]);
+
+  useEffect(() => {
+    fetch('/api/models')
+      .then((r) => r.json())
+      .then((res) => setData(res.data));
+  }, []);
+
+  const addModel = (m: LLMRecord) => setData((d) => [...d, m]);
+
+  return (
+    <main className="p-4 max-w-5xl mx-auto">
+      <h1 className="text-4xl font-bold text-center mb-8">LLM Dashboard</h1>
+      <BubbleChart data={data} />
+      <AddModelForm onAdd={addModel} />
+      <DataTable data={data} />
+    </main>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+
 body {
-  @apply bg-white text-gray-900;
+  @apply font-sans bg-neutral-0 text-neutral-900;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,14 +2,28 @@ import './globals.css';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'LLM Dashboard',
-  description: 'Elo vs price per token',
+  title: 'Ramos Analytics – Understand Your Data',
+  description: 'B2B analytics platform for A/B tests, trends and alerts.',
+  openGraph: {
+    title: 'Ramos Analytics',
+    description: 'B2B analytics platform for A/B tests, trends and alerts.',
+    url: 'https://example.com',
+    siteName: 'Ramos Analytics',
+    images: [],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Ramos Analytics',
+    description: 'B2B analytics platform for A/B tests, trends and alerts.',
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen">{children}</body>
+      <body className="min-h-screen text-body">{children}</body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,27 +1,173 @@
-'use client';
-import { useEffect, useState } from 'react';
-import BubbleChart from '../components/BubbleChart';
-import DataTable from '../components/DataTable';
-import AddModelForm from '../components/AddModelForm';
-import { LLMRecord } from '../lib/types';
+import Button from '../components/Button';
+import FAQ from '../components/FAQ';
 
-export default function Page() {
-  const [data, setData] = useState<LLMRecord[]>([]);
-
-  useEffect(() => {
-    fetch('/api/models')
-      .then((r) => r.json())
-      .then((res) => setData(res.data));
-  }, []);
-
-  const addModel = (m: LLMRecord) => setData((d) => [...d, m]);
-
+export default function Landing() {
   return (
-    <main className="p-4 max-w-5xl mx-auto">
-      <h1 className="text-4xl font-bold text-center mb-8">LLM Dashboard</h1>
-      <BubbleChart data={data} />
-      <AddModelForm onAdd={addModel} />
-      <DataTable data={data} />
+    <main>
+      {/* Hero */}
+      <section className="container mx-auto px-4 py-20 text-center">
+        <h1 className="text-display font-bold mb-6">Analytics that drive growth</h1>
+        <p className="text-h3 text-neutral-600 mb-8">
+          Turn raw product usage into actionable insights.
+        </p>
+        <div className="flex justify-center gap-4">
+          <Button href="#lead">Request a demo</Button>
+          <Button href="#lead" variant="secondary">Start for free</Button>
+        </div>
+      </section>
+
+      {/* Social proof */}
+      <section className="bg-neutral-100 py-12">
+        <div className="container mx-auto px-4 flex justify-center gap-8 opacity-75">
+          <span>Logo1</span>
+          <span>Logo2</span>
+          <span>Logo3</span>
+          <span>Logo4</span>
+        </div>
+      </section>
+
+      {/* Feature cluster */}
+      <section className="container mx-auto px-4 py-20 grid md:grid-cols-2 gap-12">
+        <div>
+          <h2 className="text-h2 font-semibold mb-4">A/B Testing</h2>
+          <p className="text-body text-neutral-600 mb-2">Run experiments and ship the best variant.</p>
+        </div>
+        <div>
+          <h2 className="text-h2 font-semibold mb-4">Trend Analysis</h2>
+          <p className="text-body text-neutral-600 mb-2">Spot shifts before they impact revenue.</p>
+        </div>
+        <div>
+          <h2 className="text-h2 font-semibold mb-4">User Segmentation</h2>
+          <p className="text-body text-neutral-600 mb-2">Understand cohorts with flexible filters.</p>
+        </div>
+        <div>
+          <h2 className="text-h2 font-semibold mb-4">Alerts</h2>
+          <p className="text-body text-neutral-600 mb-2">Get notified when metrics move unexpectedly.</p>
+        </div>
+      </section>
+
+      {/* KPI Story */}
+      <section className="bg-neutral-100 py-20">
+        <div className="container mx-auto px-4 grid md:grid-cols-3 gap-8 text-center">
+          <div className="p-6 bg-neutral-0 rounded shadow">
+            <h3 className="text-h3 font-semibold">Sales</h3>
+            <p className="text-body text-neutral-600">$128k</p>
+          </div>
+          <div className="p-6 bg-neutral-0 rounded shadow">
+            <h3 className="text-h3 font-semibold">Visitors</h3>
+            <p className="text-body text-neutral-600">32k</p>
+          </div>
+          <div className="p-6 bg-neutral-0 rounded shadow">
+            <h3 className="text-h3 font-semibold">Transactions</h3>
+            <p className="text-body text-neutral-600">4k</p>
+          </div>
+        </div>
+      </section>
+
+      {/* Deep Dive */}
+      <section className="container mx-auto px-4 py-20 space-y-16">
+        <div className="md:flex md:items-center md:gap-12">
+          <div className="md:w-1/2">
+            <h2 className="text-h2 font-semibold mb-4">All your data in one place</h2>
+            <p className="text-body text-neutral-600">Connect warehouses, marketing tools and more.</p>
+          </div>
+          <div className="md:w-1/2 bg-neutral-100 h-48" aria-hidden="true" />
+        </div>
+        <div className="md:flex md:items-center md:gap-12">
+          <div className="md:w-1/2 order-2 md:order-1">
+            <div className="bg-neutral-100 h-48" aria-hidden="true" />
+          </div>
+          <div className="md:w-1/2 order-1 md:order-2">
+            <h2 className="text-h2 font-semibold mb-4">Share insights instantly</h2>
+            <p className="text-body text-neutral-600">Dashboards update in real time for your team.</p>
+          </div>
+        </div>
+      </section>
+
+      {/* Security */}
+      <section className="bg-neutral-100 py-20">
+        <div className="container mx-auto px-4 grid md:grid-cols-3 gap-8 text-center">
+          <div>
+            <h3 className="text-h3 font-semibold mb-2">GDPR</h3>
+            <p className="text-body text-neutral-600">Compliant data processing.</p>
+          </div>
+          <div>
+            <h3 className="text-h3 font-semibold mb-2">SSO</h3>
+            <p className="text-body text-neutral-600">Secure single sign-on.</p>
+          </div>
+          <div>
+            <h3 className="text-h3 font-semibold mb-2">Roles</h3>
+            <p className="text-body text-neutral-600">Granular access control.</p>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA block */}
+      <section className="container mx-auto px-4 py-20 text-center">
+        <h2 className="text-h2 font-semibold mb-6">Ready to get started?</h2>
+        <div className="flex justify-center gap-4">
+          <Button href="#lead">Request a demo</Button>
+          <Button href="#lead" variant="secondary">Start for free</Button>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="container mx-auto px-4 py-20">
+        <h2 className="text-h2 font-semibold mb-8 text-center">FAQ</h2>
+        <FAQ />
+      </section>
+
+      {/* Lead form */}
+      <section id="lead" className="bg-neutral-100 py-20">
+        <div className="container mx-auto px-4 max-w-xl">
+          <h2 className="text-h2 font-semibold mb-6 text-center">Get Access</h2>
+          <form className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium" htmlFor="name">Name</label>
+              <input id="name" type="text" required className="mt-1 w-full rounded border border-neutral-100 p-2" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium" htmlFor="email">E-mail</label>
+              <input id="email" type="email" required className="mt-1 w-full rounded border border-neutral-100 p-2" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium" htmlFor="company">Company</label>
+              <input id="company" type="text" className="mt-1 w-full rounded border border-neutral-100 p-2" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium" htmlFor="role">Job Role</label>
+              <input id="role" type="text" className="mt-1 w-full rounded border border-neutral-100 p-2" />
+            </div>
+            <div className="flex items-center">
+              <input id="consent" type="checkbox" required className="mr-2" />
+              <label htmlFor="consent" className="text-sm text-neutral-600">
+                I agree to the processing of my data.
+              </label>
+            </div>
+            <Button href="#" variant="primary">Submit</Button>
+          </form>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="bg-neutral-900 text-neutral-0 py-12">
+        <div className="container mx-auto px-4 grid md:grid-cols-3 gap-8">
+          <div>
+            <h3 className="text-h3 font-semibold mb-4">Ramos</h3>
+            <p className="text-body text-neutral-100">© 2024 Ramos Analytics</p>
+          </div>
+          <nav className="space-y-2">
+            <a className="block" href="#">Features</a>
+            <a className="block" href="#">Pricing</a>
+            <a className="block" href="#">Contact</a>
+          </nav>
+          <div className="space-y-2">
+            <a className="block" href="#">Legal</a>
+            <a className="block" href="#">Privacy</a>
+            <a className="block" href="#">Terms</a>
+          </div>
+        </div>
+      </footer>
     </main>
   );
 }

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+type Props = {
+  href: string;
+  children: ReactNode;
+  variant?: 'primary' | 'secondary';
+};
+
+export default function Button({ href, children, variant = 'primary' }: Props) {
+  const base =
+    'inline-block rounded-md px-6 py-3 text-sm font-semibold focus:outline-none focus:ring-2 focus:ring-offset-2';
+  const styles =
+    variant === 'primary'
+      ? 'bg-accent-600 text-neutral-0 hover:bg-accent-700 focus:ring-accent-600'
+      : 'border border-accent-600 text-accent-600 hover:bg-accent-100 focus:ring-accent-600';
+  return (
+    <Link href={href} className={`${base} ${styles}`}>
+      {children}
+    </Link>
+  );
+}

--- a/components/FAQ.tsx
+++ b/components/FAQ.tsx
@@ -1,0 +1,46 @@
+interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+const faqs: FAQItem[] = [
+  {
+    question: 'What is Ramos?',
+    answer: 'Ramos is an analytics platform for data‑driven teams.',
+  },
+  {
+    question: 'Can I try it for free?',
+    answer: 'Yes, start with a free plan and upgrade when you need more.',
+  },
+  {
+    question: 'Is my data secure?',
+    answer: 'We are GDPR compliant and support SSO with granular roles.',
+  },
+  {
+    question: 'Do you offer support?',
+    answer: 'Email support is included in all plans with SLA for enterprise.',
+  },
+  {
+    question: 'Can I cancel anytime?',
+    answer: 'You can cancel your subscription at any time from the dashboard.',
+  },
+  {
+    question: 'Do you integrate with other tools?',
+    answer: 'Ramos connects to popular data warehouses and marketing platforms.',
+  },
+];
+
+export default function FAQ() {
+  return (
+    <div className="space-y-4">
+      {faqs.map((f, i) => (
+        <details key={i} className="border-b pb-4">
+          <summary className="cursor-pointer text-h3">
+            {f.question}
+          </summary>
+          <p className="mt-2 text-body text-neutral-600">{f.answer}</p>
+        </details>
+      ))}
+    </div>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,31 @@
 module.exports = {
   content: ["./app/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        accent: {
+          100: '#FFE5DE',
+          600: '#FF6F50',
+          700: '#E65B3F',
+        },
+        neutral: {
+          0: '#FFFFFF',
+          100: '#F5F5F5',
+          600: '#6B7280',
+          900: '#111827',
+        },
+      },
+      fontFamily: {
+        sans: ['"Inter Variable"', 'sans-serif'],
+      },
+      fontSize: {
+        display: ['72px', { lineHeight: '80px', fontWeight: '700' }],
+        h2: ['48px', { lineHeight: '56px', fontWeight: '600' }],
+        h3: ['28px', { lineHeight: '36px', fontWeight: '600' }],
+        body: ['16px', { lineHeight: '24px' }],
+        caption: ['13px', { lineHeight: '18px' }],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- extend Tailwind with brand colors and type scale
- add landing page sections with hero, features, FAQ and lead form
- factor reusable Button and FAQ components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898d2dc31b883219fdee687d41eda46