### PR TITLE
feat: add benchmark filtering and company colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 Minimal Next.js app that visualizes LLM models.
 
 ## Features
-- Bubble chart of Elo score (x) vs inverse price per token (y).
+- Bubble chart of benchmark score (x) vs inverse price per token (y).
 - Bubble size reflects context window; legend shows common sizes.
-- Color legend distinguishes open, closed and hybrid weights; icons mark image, speech and reasoning capabilities.
+- Models are colored by company; legend lists all models and greys out those filtered out.
+- Filter at the top switches between benchmarks; the selected benchmark's description is shown at the bottom.
 - The `features` column accepts semicolon-separated values. Icons are shown for `image` (🖼️) and `speech` (🗣️); other entries are rendered as plain text.
 - Data loaded from CSV (`data/models.csv`) and mirrored in a table beneath the chart.
 - `/api/models?source=URL` allows switching to other CSV/JSON sources.

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,27 +1,105 @@
 'use client';
 import { useEffect, useState } from 'react';
-import BubbleChart from '../components/BubbleChart';
-import DataTable from '../components/DataTable';
-import AddModelForm from '../components/AddModelForm';
-import { LLMRecord } from '../lib/types';
+import BubbleChart from '../../components/BubbleChart';
+import DataTable from '../../components/DataTable';
+import AddModelForm from '../../components/AddModelForm';
+import { LLMRecord } from '../../lib/types';
 
 export default function Page() {
   const [data, setData] = useState<LLMRecord[]>([]);
+  const [benchmark, setBenchmark] = useState('');
 
   useEffect(() => {
     fetch('/api/models')
       .then((r) => r.json())
-      .then((res) => setData(res.data));
+      .then((res) => {
+        setData(res.data);
+        const first = res.data[0]?.benchmark;
+        if (first) setBenchmark(first);
+      });
   }, []);
 
   const addModel = (m: LLMRecord) => setData((d) => [...d, m]);
 
+  const benchmarks = Array.from(new Set(data.map((d) => d.benchmark)));
+  const filtered = data.filter((d) => d.benchmark === benchmark);
+
+  const palette = [
+    '#e6194b',
+    '#3cb44b',
+    '#ffe119',
+    '#4363d8',
+    '#f58231',
+    '#911eb4',
+    '#46f0f0',
+    '#f032e6',
+    '#bcf60c',
+    '#fabebe',
+    '#008080',
+    '#e6beff',
+    '#9a6324',
+    '#fffac8',
+    '#800000',
+    '#aaffc3',
+    '#808000',
+    '#ffd8b1',
+    '#000075',
+    '#808080',
+  ];
+  const companyColors: Record<string, string> = {};
+  data.forEach((d) => {
+    if (!companyColors[d.company]) {
+      const idx = Object.keys(companyColors).length % palette.length;
+      companyColors[d.company] = palette[idx];
+    }
+  });
+
+  const uniqueModels = Array.from(
+    new Map(data.map((d) => [d.model, d])).values()
+  );
+
   return (
     <main className="p-4 max-w-5xl mx-auto">
       <h1 className="text-4xl font-bold text-center mb-8">LLM Dashboard</h1>
-      <BubbleChart data={data} />
+      <div className="mb-4 flex justify-center">
+        <select
+          className="border p-2"
+          value={benchmark}
+          onChange={(e) => setBenchmark(e.target.value)}
+        >
+          {benchmarks.map((b) => (
+            <option key={b} value={b}>
+              {b}
+            </option>
+          ))}
+        </select>
+      </div>
+      <BubbleChart data={filtered} companyColors={companyColors} />
+      <div className="flex flex-wrap gap-4 mt-4 text-sm justify-center">
+        {uniqueModels.map((m) => {
+          const visible = filtered.some((f) => f.model === m.model);
+          return (
+            <div
+              key={m.model}
+              className="flex items-center gap-1"
+              style={{ opacity: visible ? 1 : 0.3 }}
+            >
+              <span
+                className="w-3 h-3 rounded-sm"
+                style={{
+                  backgroundColor: visible
+                    ? companyColors[m.company]
+                    : '#ccc',
+                }}
+              ></span>
+              <span>{m.model}</span>
+            </div>
+          );
+        })}
+      </div>
       <AddModelForm onAdd={addModel} />
-      <DataTable data={data} />
+      <DataTable data={filtered} />
+      <p className="mt-4 text-sm text-center">{filtered[0]?.benchmarkText}</p>
     </main>
   );
 }

--- a/components/AddModelForm.tsx
+++ b/components/AddModelForm.tsx
@@ -4,12 +4,15 @@ import { LLMRecord, Weight } from '../lib/types';
 
 const empty: LLMRecord = {
   model: '',
+  company: '',
   elo: 0,
   price: 0,
   context: 32000,
   weight: 'open',
   reasoning: false,
   features: [],
+  benchmark: '',
+  benchmarkText: '',
 };
 
 export default function AddModelForm({ onAdd }: { onAdd: (m: LLMRecord) => void }) {
@@ -28,6 +31,13 @@ export default function AddModelForm({ onAdd }: { onAdd: (m: LLMRecord) => void 
         value={form.model}
         onChange={(e) => setForm({ ...form, model: e.target.value })}
         placeholder="Model"
+        className="border p-1"
+      />
+      <input
+        required
+        value={form.company}
+        onChange={(e) => setForm({ ...form, company: e.target.value })}
+        placeholder="Company"
         className="border p-1"
       />
       <input
@@ -84,6 +94,20 @@ export default function AddModelForm({ onAdd }: { onAdd: (m: LLMRecord) => void 
           })
         }
         placeholder="features"
+        className="border p-1"
+      />
+      <input
+        required
+        value={form.benchmark}
+        onChange={(e) => setForm({ ...form, benchmark: e.target.value })}
+        placeholder="Benchmark"
+        className="border p-1"
+      />
+      <input
+        required
+        value={form.benchmarkText}
+        onChange={(e) => setForm({ ...form, benchmarkText: e.target.value })}
+        placeholder="Benchmark text"
         className="border p-1"
       />
       <button type="submit" className="bg-black text-white px-2 py-1">

--- a/components/BubbleChart.tsx
+++ b/components/BubbleChart.tsx
@@ -11,12 +11,6 @@ import { LLMRecord } from '../lib/types';
 
 ChartJS.register(LinearScale, PointElement, Tooltip, Legend);
 
-const colors: Record<string, string> = {
-  open: 'rgba(34,197,94,0.5)',
-  closed: 'rgba(239,68,68,0.5)',
-  hybrid: 'rgba(59,130,246,0.5)',
-};
-
 function radius(context: number) {
   if (context >= 1_000_000) return 40;
   if (context >= 200_000) return 30;
@@ -25,7 +19,7 @@ function radius(context: number) {
   return 10;
 }
 
-export default function BubbleChart({ data }: { data: LLMRecord[] }) {
+export default function BubbleChart({ data, companyColors }: { data: LLMRecord[]; companyColors: Record<string, string> }) {
   const chartData = {
     datasets: [
       {
@@ -36,8 +30,8 @@ export default function BubbleChart({ data }: { data: LLMRecord[] }) {
           r: radius(d.context),
           ...d,
         })),
-        backgroundColor: data.map((d) => colors[d.weight]),
-        borderColor: data.map((d) => colors[d.weight]),
+        backgroundColor: data.map((d) => companyColors[d.company]),
+        borderColor: data.map((d) => companyColors[d.company]),
       },
     ],
   };
@@ -66,14 +60,6 @@ export default function BubbleChart({ data }: { data: LLMRecord[] }) {
   return (
     <div className="w-full">
       <Bubble data={chartData} options={options} />
-      <div className="flex flex-wrap gap-4 mt-4 text-sm">
-        {Object.entries(colors).map(([k, v]) => (
-          <div key={k} className="flex items-center gap-1">
-            <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: v }}></span>
-            <span className="capitalize">{k}</span>
-          </div>
-        ))}
-      </div>
       <div className="flex flex-wrap gap-4 mt-2 text-sm items-center">
         {contextLegend.map((c) => (
           <div key={c} className="flex items-center gap-1">

--- a/components/DataTable.tsx
+++ b/components/DataTable.tsx
@@ -8,24 +8,28 @@ export default function DataTable({ data }: { data: LLMRecord[] }) {
       <thead className="bg-gray-100">
         <tr>
           <th className="p-2 text-left">Model</th>
+          <th className="p-2 text-left">Company</th>
           <th className="p-2 text-left">Elo</th>
           <th className="p-2 text-left">$/token</th>
           <th className="p-2 text-left">Context</th>
           <th className="p-2 text-left">Weights</th>
           <th className="p-2 text-left">Reasoning</th>
           <th className="p-2 text-left">Features</th>
+          <th className="p-2 text-left">Benchmark</th>
         </tr>
       </thead>
       <tbody>
         {data.map((d) => (
           <tr key={d.model} className="border-t">
             <td className="p-2">{d.model}</td>
+            <td className="p-2">{d.company}</td>
             <td className="p-2">{d.elo}</td>
             <td className="p-2">{d.price}</td>
             <td className="p-2">{d.context.toLocaleString()}</td>
             <td className="p-2 capitalize">{d.weight}</td>
             <td className="p-2">{d.reasoning ? '🧠' : ''}</td>
             <td className="p-2">{d.features?.map((f) => (f === 'image' ? '🖼️' : f === 'speech' ? '🗣️' : f)).join(' ')}</td>
+            <td className="p-2">{d.benchmark}</td>
           </tr>
         ))}
       </tbody>

--- a/data/models.csv
+++ b/data/models.csv
@@ -1,6 +1,9 @@
-model,elo,price,context,weight,reasoning,features
-GPT-4o,1235,0.00001,128000,closed,true,"image;speech"
-Claude 3.5 Sonnet,1220,0.000008,200000,closed,true,"image"
-Llama3-70B,1180,0.000002,128000,open,false,""
-Gemini 1.5 Pro,1195,0.000007,1000000,hybrid,true,"image;speech"
-Mistral Small,1150,0.0000015,32000,open,false,""
+model,company,elo,price,context,weight,reasoning,features,benchmark,benchmarkText
+GPT-4o,OpenAI,1235,0.00001,128000,closed,true,"image;speech",lmsys,"LMSYS Chatbot Arena Elo benchmark"
+Claude 3.5 Sonnet,Anthropic,1220,0.000008,200000,closed,true,"image",lmsys,"LMSYS Chatbot Arena Elo benchmark"
+Llama3-70B,Meta,1180,0.000002,128000,open,false,"",lmsys,"LMSYS Chatbot Arena Elo benchmark"
+Gemini 1.5 Pro,Google,1195,0.000007,1000000,hybrid,true,"image;speech",lmsys,"LMSYS Chatbot Arena Elo benchmark"
+Mistral Small,Mistral,1150,0.0000015,32000,open,false,"",lmsys,"LMSYS Chatbot Arena Elo benchmark"
+GPT-4o,OpenAI,85,0.00001,128000,closed,true,"image;speech",mmlu,"Massive Multitask Language Understanding accuracy"
+Claude 3.5 Sonnet,Anthropic,82,0.000008,200000,closed,true,"image",mmlu,"Massive Multitask Language Understanding accuracy"
+Llama3-70B,Meta,75,0.000002,128000,open,false,"",mmlu,"Massive Multitask Language Understanding accuracy"

--- a/data/models_template.csv
+++ b/data/models_template.csv
@@ -1,3 +1,3 @@
-model,elo,price,context,weight,reasoning,features
+model,company,elo,price,context,weight,reasoning,features,benchmark,benchmarkText
 # features: semicolon-separated; known values include image and speech (icons provided). Other entries will display as text.
-example-model,0,0,0,open,false,"image;speech"
+example-model,ExampleCorp,0,0,0,open,false,"image;speech",benchmark-name,"short description of the benchmark"

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -10,9 +10,17 @@ export async function loadCSV(source?: string): Promise<LLMRecord[]> {
   } else {
     csv = await fs.readFile(process.cwd() + '/data/models.csv', 'utf8');
   }
-  const { data } = Papa.parse<LLMRecord>(csv, {
+  const { data } = Papa.parse<any>(csv, {
     header: true,
     dynamicTyping: true,
   });
-  return data.filter((d) => d.model);
+  return data
+    .filter((d: any) => d.model)
+    .map((d: any) => ({
+      ...d,
+      features:
+        typeof d.features === 'string'
+          ? d.features.split(';').filter(Boolean)
+          : d.features || [],
+    }));
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2,10 +2,13 @@ export type Weight = 'open' | 'closed' | 'hybrid';
 
 export interface LLMRecord {
   model: string;
+  company: string;
   elo: number;
   price: number; // price per token in USD
   context: number; // context window size
   weight: Weight;
   reasoning: boolean;
   features: string[]; // e.g. ['image','speech']
+  benchmark: string;
+  benchmarkText: string;
 }


### PR DESCRIPTION
## Summary
- add benchmark and company fields to model data with CSV template update
- color bubbles by company and provide benchmark filter, model legend, and description
- parse semicolon feature lists from CSV

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898d49b5f9c8321875180cf4413aa8e