### PR TITLE
Handle API load failures on dashboard

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -13,9 +13,16 @@ export default function Page() {
     fetch('/api/models')
       .then((r) => r.json())
       .then((res) => {
-        setData(res.data);
-        const first = res.data[0]?.benchmark;
-        if (first) setBenchmark(first);
+        if (res.data) {
+          setData(res.data);
+          const first = res.data[0]?.benchmark;
+          if (first) setBenchmark(first);
+        } else {
+          console.error(res.error || 'Failed to load models');
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to load models', err);
       });
   }, []);
 


### PR DESCRIPTION
## Summary
- avoid client crash by checking for errors when loading models

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898eabe831c83218b85fdc692b33329