### PR TITLE
Add comprehensive unit tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Next.js 14 app to compute BTC options max-pain from Deribit public data.
 
-## Development
+## Start
 
 ```bash
 pnpm install
@@ -17,9 +17,20 @@ pnpm quality
 
 ## Deploy
 
-Deploy on Vercel. Set build command `pnpm build` and install command `pnpm install`.
+Deploy on [Vercel](https://vercel.com). Use the Node.js runtime. Install command `pnpm install` and build command `pnpm build`. Optional cron warmup is defined in `vercel.json`.
+
+## Limits
+
+- Deribit public API is cached on the server for 30s and revalidated on the client every 60s.
+- Exponential backoff with two retries guards against 429 and network errors.
+- Data units are in BTC; max pain strike is reported in USD.
+
+## Known Pitfalls
+
+- If no instruments exist for a date, the API returns `maxPain: NaN` with an issue message.
+- Bypassing cache may hit Deribit rate limits.
 
 ## Method
 
-Open interest per strike is aggregated from `get_book_summary_by_currency`.
-Max pain is strike minimizing combined loss of puts and calls.
+Open interest per strike is aggregated from `get_book_summary_by_currency`. Max pain is the strike `S` minimizing
+`Σ[OI_call(K)*max(0,S−K)+OI_put(K)*max(0,K−S)]`.

--- a/__tests__/maxpain.test.ts
+++ b/__tests__/maxpain.test.ts
@@ -1,28 +1,57 @@
 import { computeMaxPain, parseInstrumentName, filterByDate } from '@/lib/maxpain';
 import type { BookSummary } from '@/lib/deribit';
 
-test('parseInstrumentName parses correctly', () => {
-  const p = parseInstrumentName('BTC-1JAN25-50000-C');
-  expect(p).toEqual({ dateISO: '2025-01-01', strike: 50000, type: 'C' });
-  expect(parseInstrumentName('invalid')).toBeNull();
+describe('instrument parser', () => {
+  it('parses valid names', () => {
+    expect(parseInstrumentName('BTC-1JAN25-50000-C')).toEqual({
+      dateISO: '2025-01-01',
+      strike: 50000,
+      type: 'C',
+    });
+    expect(parseInstrumentName('BTC-01FEB25-10000-P')).toEqual({
+      dateISO: '2025-02-01',
+      strike: 10000,
+      type: 'P',
+    });
+  });
+  it('rejects invalid names', () => {
+    expect(parseInstrumentName('BTC-1FOO25-100-C')).toBeNull();
+    expect(parseInstrumentName('invalid')).toBeNull();
+  });
 });
 
-test('computeMaxPain simple grid', () => {
-  const items = [
-    { dateISO: '2025-01-01', strike: 100, type: 'C', oi: 1 },
-    { dateISO: '2025-01-01', strike: 200, type: 'P', oi: 1 },
+describe('max pain computation', () => {
+  it('finds analytic minimum on symmetric grid', () => {
+    const items = [
+      { dateISO: '2025-01-01', strike: 100, type: 'C', oi: 1 },
+      { dateISO: '2025-01-01', strike: 200, type: 'C', oi: 1 },
+      { dateISO: '2025-01-01', strike: 200, type: 'P', oi: 1 },
+      { dateISO: '2025-01-01', strike: 300, type: 'P', oi: 1 },
+    ];
+    const res = computeMaxPain(items);
+    expect(res.maxPain).toBe(200);
+    expect(res.oiCallsBTC).toBe(2);
+    expect(res.oiPutsBTC).toBe(2);
+  });
+  it('handles asymmetric puts and calls', () => {
+    const items = [
+      { dateISO: '2025-01-01', strike: 100, type: 'C', oi: 5 },
+      { dateISO: '2025-01-01', strike: 100, type: 'P', oi: 15 },
+      { dateISO: '2025-01-01', strike: 200, type: 'P', oi: 10 },
+    ];
+    const res = computeMaxPain(items);
+    expect(res.putCallRatio).toBeCloseTo((15 + 10) / 5);
+  });
+});
+
+describe('filtering', () => {
+  const mockBook: BookSummary[] = [
+    { instrument_name: 'BTC-1JAN25-100-C', open_interest: 1 },
+    { instrument_name: 'BTC-1JAN25-100-P', open_interest: 2 },
+    { instrument_name: 'BTC-8JAN25-200-C', open_interest: 3 },
   ];
-  const res = computeMaxPain(items);
-  expect(res.maxPain).toBe(100);
-});
-
-const mockBook: BookSummary[] = [
-  { instrument_name: 'BTC-1JAN25-100-C', open_interest: 1 },
-  { instrument_name: 'BTC-1JAN25-100-P', open_interest: 2 },
-  { instrument_name: 'BTC-8JAN25-200-C', open_interest: 3 },
-];
-
-test('filterByDate filters instruments', () => {
-  const items = filterByDate(mockBook, '2025-01-01');
-  expect(items.length).toBe(2);
+  it('filters instruments by ISO date', () => {
+    const items = filterByDate(mockBook, '2025-01-01');
+    expect(items).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
## Summary
- expand unit tests for parser and max-pain computation
- document start, deploy, limits, and method

## Testing
- `pnpm test:unit`
- `pnpm test:integration`
- `pnpm test:perf`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a721c344648321b854763da53166ff