### PR TITLE
Limit cron schedule for Hobby plan

### DIFF
--- a/__tests__/vercel-cron.test.ts
+++ b/__tests__/vercel-cron.test.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+
+test('vercel cron configuration meets Hobby plan limitations', () => {
+  const config = JSON.parse(fs.readFileSync('vercel.json', 'utf8'));
+
+  console.log('Hobby plan limitations:');
+  console.log('- Maximum of one cron job');
+  console.log('- Minimum schedule frequency is once per day');
+
+  expect(Array.isArray(config.crons)).toBe(true);
+  expect(config.crons).toHaveLength(1);
+
+  const { schedule, path } = config.crons[0];
+  expect(schedule).toBe('0 0 * * *');
+  expect(path.startsWith('/api/')).toBe(true);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "crons": [
-    { "path": "/api/maxpain?dates=2025-01-01", "schedule": "0 * * * *" }
+    { "path": "/api/maxpain?dates=2025-01-01", "schedule": "0 0 * * *" }
   ]
 }


### PR DESCRIPTION
## Summary
- adjust cron job schedule to run once per day, which fits the Vercel Hobby plan limitations
- add test emitting Hobby plan cron limitations and verifying configuration

## Testing
- `npm run lint`
- `npm run test:unit`
- `npm run test:integration`
- `npm run test:perf`
- `npx jest __tests__/vercel-cron.test.ts`
- `npm run quality`


------
https://chatgpt.com/codex/tasks/task_e_68a9caa789d88321ba5b894a76873fa5