### PR TITLE
fix(ci): align pnpm version with lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Summary
- use pnpm 9 in CI to match pnpm-lock.yaml

## Testing
- `pnpm test:unit`
- `pnpm test:integration`
- `pnpm test:perf`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c8099ea7008321b30198c093b89a38