### PR TITLE
fix: ensure pnpm lockfile compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
       - run: pnpm install --frozen-lockfile
       - run: pnpm quality


### PR DESCRIPTION
## Summary
- install Node before pnpm in CI to keep pnpm@9

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm quality`


------
https://chatgpt.com/codex/tasks/task_e_68c80b621f748321866e92fea6161a99