### PR TITLE
feat: adopt Airbnb-inspired dark theme

### DIFF
--- a/__mocks__/geist-font.ts
+++ b/__mocks__/geist-font.ts
@@ -1,9 +1,0 @@
-export const GeistSans = {
-  className: 'mock-geist-sans',
-  variable: '--font-geist-sans',
-};
-
-export const GeistMono = {
-  className: 'mock-geist-mono',
-  variable: '--font-geist-mono',
-};

--- a/__tests__/layout.test.tsx
+++ b/__tests__/layout.test.tsx
@@ -3,7 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import RootLayout from '../app/layout';
 
 describe('RootLayout', () => {
-  it('applies Geist font variables', () => {
+  it('applies IBM Plex font variables', () => {
     const html = renderToStaticMarkup(
       React.createElement(
         RootLayout,
@@ -11,7 +11,7 @@ describe('RootLayout', () => {
         React.createElement('div', null, 'child')
       )
     );
-    expect(html).toContain('--font-geist-sans');
-    expect(html).toContain('--font-geist-mono');
+    expect(html).toContain('--font-ibm-plex-sans');
+    expect(html).toContain('--font-ibm-plex-mono');
   });
 });

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,26 +1,32 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #1f1f1f;
+  --foreground: #f5f5f5;
+  --accent: #ff5a5f;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  --color-accent: var(--accent);
+  --font-sans: var(--font-ibm-plex-sans);
+  --font-mono: var(--font-ibm-plex-mono);
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-ibm-plex-sans), sans-serif;
+  line-height: 1.6;
+}
+
+a {
+  color: var(--accent);
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+a:hover {
+  color: var(--foreground);
+  background-color: var(--accent);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,18 @@
 import type { Metadata } from "next";
-import { GeistSans } from "geist/font/sans";
-import { GeistMono } from "geist/font/mono";
+import { IBM_Plex_Sans, IBM_Plex_Mono } from "next/font/google";
 import "./globals.css";
 
-export const geistSans = GeistSans;
+export const ibmPlexSans = IBM_Plex_Sans({
+  subsets: ["latin"],
+  weight: ["400", "700"],
+  variable: "--font-ibm-plex-sans",
+});
 
-export const geistMono = GeistMono;
+export const ibmPlexMono = IBM_Plex_Mono({
+  subsets: ["latin"],
+  weight: ["400", "700"],
+  variable: "--font-ibm-plex-mono",
+});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -20,7 +27,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${ibmPlexSans.variable} ${ibmPlexMono.variable} antialiased`}
       >
         {children}
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,35 +4,51 @@ import { loadItems } from '@/lib/trips';
 export default function Page() {
   const items = loadItems();
   return (
-    <main className="p-4">
-      <nav className="mb-6 flex flex-wrap gap-4">
+    <main className="mx-auto max-w-3xl p-6">
+      <nav className="mb-8 flex flex-wrap gap-3">
         {items.map((item) => (
-          <a key={item.id} href={`#${item.id}`} className="text-blue-600 underline">
+          <a
+            key={item.id}
+            href={`#${item.id}`}
+            className="rounded-full bg-accent px-3 py-1 text-sm text-background no-underline hover:bg-foreground hover:text-background"
+          >
             {item.name}
           </a>
         ))}
       </nav>
       {items.map((item) => (
-        <section key={item.id} id={item.id} className="mb-12">
-          <h2 className="text-2xl font-bold mb-2">{item.name}</h2>
+        <section
+          key={item.id}
+          id={item.id}
+          className="mb-12 rounded-lg bg-[#2a2a2a] p-6 shadow"
+        >
+          <h2 className="mb-4 text-2xl font-bold text-accent">{item.name}</h2>
           <Image
             src={item.image}
             alt={item.name}
             width={800}
             height={400}
-            className="mb-2 h-auto w-full"
+            className="mb-4 h-auto w-full rounded"
           />
-          <p className="mb-2">{item.description}</p>
-          <p className="mb-2"><strong>Planung:</strong> {item.planning}</p>
-          <p className="mb-2"><strong>Organisation:</strong> {item.organizing}</p>
-          <p className="mb-2"><strong>Fahrtzeit:</strong> {item.drive_min} Min.</p>
-          <p className="mb-2"><strong>Kategorie:</strong> {item.category.join(', ')}</p>
+          <p className="mb-2 text-foreground">{item.description}</p>
+          <p className="mb-2">
+            <strong>Planung:</strong> {item.planning}
+          </p>
+          <p className="mb-2">
+            <strong>Organisation:</strong> {item.organizing}
+          </p>
+          <p className="mb-2">
+            <strong>Fahrtzeit:</strong> {item.drive_min} Min.
+          </p>
+          <p className="mb-2">
+            <strong>Kategorie:</strong> {item.category.join(', ')}
+          </p>
           <ul className="list-inside list-disc">
             {item.links.map((l) => (
               <li key={l.url}>
                 <a
                   href={l.url}
-                  className="text-blue-600 underline"
+                  className="rounded px-1 text-accent underline hover:bg-accent hover:text-background"
                   target="_blank"
                   rel="noreferrer"
                 >

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,6 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   moduleNameMapper: {
-    '^geist/font/.*$': '<rootDir>/__mocks__/geist-font.ts',
     '^@/(.*)$': '<rootDir>/$1',
     '\\.(css|scss|sass)$': '<rootDir>/__mocks__/style-mock.js',
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "quality": "node quality.js"
   },
   "dependencies": {
-    "geist": "^1.5.1",
     "next": "15.5.0",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      geist:
-        specifier: ^1.5.1
-        version: 1.5.1(next@15.5.0(@babel/core@7.28.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       next:
         specifier: 15.5.0
         version: 15.5.0(@babel/core@7.28.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1616,10 +1613,6 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
-  geist@1.5.1:
-    resolution: {integrity: sha512-mAHZxIsL2o3ZITFaBVFBnwyDOw+zNLYum6A6nIjpzCGIO8QtC3V76XF2RnZTyLx1wlDTmMDy8jg3Ib52MIjGvQ==}
-    peerDependencies:
-      next: '>=13.2.0'
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -4793,10 +4786,6 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
-
-  geist@1.5.1(next@15.5.0(@babel/core@7.28.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
-    dependencies:
-      next: 15.5.0(@babel/core@7.28.3)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   gensync@1.0.0-beta.2: {}
 


### PR DESCRIPTION
## Summary
- switch site fonts to IBM Plex and drop unused Geist dependency
- add Airbnb-inspired dark palette with accent links
- spruce up trip page layout for better readability

## Testing
- `pnpm lint`
- `pnpm test:unit`
- `pnpm test:integration`
- `pnpm test:perf`
- `pnpm quality`


------
https://chatgpt.com/codex/tasks/task_e_68c81de59df883219a95e663bead6495