### PR TITLE
Configure remote image domains for Next.js 15

### DIFF
--- a/__tests__/image-config.test.ts
+++ b/__tests__/image-config.test.ts
@@ -1,0 +1,11 @@
+import config from '../next.config';
+
+describe('image remotePatterns configuration', () => {
+  it('allows wikimedia and unsplash', () => {
+    const patterns = config.images?.remotePatterns ?? [];
+    const hosts = patterns.map((p) => p.hostname);
+    expect(hosts).toEqual(
+      expect.arrayContaining(['upload.wikimedia.org', 'images.unsplash.com'])
+    );
+  });
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,11 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: {
-    domains: ["upload.wikimedia.org", "images.unsplash.com"],
+    remotePatterns: [
+      { protocol: 'https', hostname: 'upload.wikimedia.org' },
+      { protocol: 'https', hostname: 'images.unsplash.com' },
+    ],
+    formats: ['image/avif', 'image/webp'],
   },
 };
 


### PR DESCRIPTION
## Summary
- use `remotePatterns` to allow wikimedia and unsplash images
- add regression test for image config

## Testing
- `npm run lint`
- `npm run test:unit`
- `npx jest __tests__/image-config.test.ts`
- `npm run test:integration`
- `npm run test:perf`
- `npm run quality`
- `npm run build` *(fails: Error while requesting resource, Failed to fetch `IBM Plex Mono` and `IBM Plex Sans` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c81fa367808321a1457175a6c3743d