### PR TITLE
Use system font stack and simple image tags

### DIFF
--- a/__tests__/layout.test.tsx
+++ b/__tests__/layout.test.tsx
@@ -3,7 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import RootLayout from '../app/layout';
 
 describe('RootLayout', () => {
-  it('applies IBM Plex font variables', () => {
+  it('renders children with antialiased class', () => {
     const html = renderToStaticMarkup(
       React.createElement(
         RootLayout,
@@ -11,7 +11,7 @@ describe('RootLayout', () => {
         React.createElement('div', null, 'child')
       )
     );
-    expect(html).toContain('--font-ibm-plex-sans');
-    expect(html).toContain('--font-ibm-plex-mono');
+    expect(html).toContain('antialiased');
+    expect(html).toContain('child');
   });
 });

--- a/app/globals.css
+++ b/app/globals.css
@@ -10,14 +10,14 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-accent: var(--accent);
-  --font-sans: var(--font-ibm-plex-sans);
-  --font-mono: var(--font-ibm-plex-mono);
+  --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "SFMono-Regular", Menlo, monospace;
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-ibm-plex-sans), sans-serif;
+  font-family: var(--font-sans);
   line-height: 1.6;
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,18 +1,5 @@
 import type { Metadata } from "next";
-import { IBM_Plex_Sans, IBM_Plex_Mono } from "next/font/google";
 import "./globals.css";
-
-export const ibmPlexSans = IBM_Plex_Sans({
-  subsets: ["latin"],
-  weight: ["400", "700"],
-  variable: "--font-ibm-plex-sans",
-});
-
-export const ibmPlexMono = IBM_Plex_Mono({
-  subsets: ["latin"],
-  weight: ["400", "700"],
-  variable: "--font-ibm-plex-mono",
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -26,11 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${ibmPlexSans.variable} ${ibmPlexMono.variable} antialiased`}
-      >
-        {children}
-      </body>
+      <body className="antialiased">{children}</body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import { loadItems } from '@/lib/trips';
 
 export default function Page() {
@@ -23,11 +22,12 @@ export default function Page() {
           className="mb-12 rounded-lg bg-[#2a2a2a] p-6 shadow"
         >
           <h2 className="mb-4 text-2xl font-bold text-accent">{item.name}</h2>
-          <Image
+          <img
             src={item.image}
             alt={item.name}
             width={800}
             height={400}
+            loading="lazy"
             className="mb-4 h-auto w-full rounded"
           />
           <p className="mb-2 text-foreground">{item.description}</p>


### PR DESCRIPTION
## Summary
- drop Google font imports and rely on system font stack for sans and mono
- render remote images with standard `<img>` tags to avoid placeholders
- adjust layout test to match font and markup changes

## Testing
- `pnpm lint`
- `pnpm test:unit`
- `pnpm test:integration`
- `pnpm test:perf`
- `pnpm quality`


------
https://chatgpt.com/codex/tasks/task_e_68c82504dca4832197478eacc79a0f58