### PR TITLE
Add Apple Maps navigation links to trip items

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,29 @@ Deploy on [Vercel](https://vercel.com). Use the Node.js runtime. Install command
 
 Open interest per strike is aggregated from `get_book_summary_by_currency`. Max pain is the strike `S` minimizing
 `Σ[OI_call(K)*max(0,S−K)+OI_put(K)*max(0,K−S)]`.
+
+## Trip Item Template
+
+Use this snippet to add new entries in `data/*.json`. The Apple Maps link
+provides driving directions in CarPlay and is derived from `map_query`.
+
+```json
+{
+  "id": "example_id",
+  "name": "Example Name",
+  "category": ["Stadt & Kultur"],
+  "popularity": 0,
+  "drive_min": 0,
+  "description": "Kurzbeschreibung.",
+  "planning": "Planungshinweise.",
+  "organizing": "Organisationshinweise.",
+  "links": [
+    {
+      "title": "Apple Maps",
+      "url": "https://maps.apple.com/?daddr=Example%20Place&dirflg=d"
+    }
+  ],
+  "image": "https://example.com/image.jpg",
+  "map_query": "Example Place"
+}
+```

--- a/__tests__/trips.test.ts
+++ b/__tests__/trips.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { loadItems } from '@/lib/trips';
+import { appleMapsLink, loadItems } from '@/lib/trips';
 
 describe('loadItems', () => {
   const dataDir = path.join(process.cwd(), 'data');
@@ -41,5 +41,23 @@ describe('loadItems', () => {
     fs.writeFileSync(tempFile, JSON.stringify(extra));
     const items = loadItems();
     expect(items.find((i) => i.id === 'extra_item')).toBeTruthy();
+  });
+
+  it('adds an Apple Maps link based on map_query', () => {
+    const items = loadItems();
+    const item = items[0];
+    const apple = item.links.find((l) => l.title === 'Apple Maps');
+    expect(apple).toBeTruthy();
+    expect(apple?.url).toContain('maps.apple.com');
+  });
+});
+
+describe('appleMapsLink', () => {
+  it('encodes query for driving directions', () => {
+    const link = appleMapsLink('San Francisco');
+    expect(link).toEqual({
+      title: 'Apple Maps',
+      url: 'https://maps.apple.com/?daddr=San%20Francisco&dirflg=d',
+    });
   });
 });

--- a/lib/trips.ts
+++ b/lib/trips.ts
@@ -20,6 +20,19 @@ export interface Item {
   map_query: string;
 }
 
+/**
+ * Create a link to Apple Maps with driving directions for CarPlay.
+ * Runs in O(n) time where n is the length of the query due to encoding.
+ */
+export function appleMapsLink(query: string): Link {
+  const q = query.trim();
+  if (!q) {
+    throw new Error('map_query is required to build Apple Maps link');
+  }
+  const url = `https://maps.apple.com/?daddr=${encodeURIComponent(q)}&dirflg=d`;
+  return { title: 'Apple Maps', url };
+}
+
 export interface TripData {
   meta: {
     base: string;
@@ -44,5 +57,14 @@ export function loadItems(): Item[] {
   const trips = loadTrips();
   const items = trips.flatMap((t) => t.items);
   items.sort((a, b) => b.popularity - a.popularity);
+  items.forEach((item) => {
+    if (item.map_query.trim()) {
+      const link = appleMapsLink(item.map_query);
+      const exists = item.links.some((l) => l.url === link.url);
+      if (!exists) {
+        item.links.unshift(link);
+      }
+    }
+  });
   return items;
 }


### PR DESCRIPTION
## Summary
- auto-generate Apple Maps CarPlay links from each item's `map_query`
- document trip item template including Apple Maps link
- test Apple Maps link creation and injection into items

## Testing
- `pnpm jest __tests__/trips.test.ts`
- `pnpm quality`


------
https://chatgpt.com/codex/tasks/task_e_68c82af9cbb08321be81009611534c97