### PR TITLE
Render full place details from JSON data

### DIFF
--- a/__tests__/trips.test.ts
+++ b/__tests__/trips.test.ts
@@ -46,9 +46,37 @@ describe('loadItems', () => {
   it('adds an Apple Maps link based on map_query', () => {
     const items = loadItems();
     const item = items[0];
-    const apple = item.links.find((l) => l.title === 'Apple Maps');
+    const apple = item.links?.find((l) => l.title === 'Apple Maps');
     expect(apple).toBeTruthy();
     expect(apple?.url).toContain('maps.apple.com');
+  });
+
+  it('retains optional fields and builds map links', () => {
+    const extra = {
+      meta: { base: 'Test', max_drive_min: 1, date_window: '', sort: 'popularity_desc' },
+      items: [
+        {
+          id: 'optional_item',
+          name: 'Optional Item',
+          category: 'test',
+          drive_time_min: 5,
+          duration_suggested_min: 10,
+          price_hint: 'kostenlos',
+          coords: { lat: 1, lon: 2 },
+          apple_maps_url: 'https://maps.apple.com/?q=1,2',
+          google_maps_url: 'https://maps.google.com/?q=1,2',
+          tags: ['a', 'b']
+        }
+      ]
+    };
+    fs.writeFileSync(tempFile, JSON.stringify(extra));
+    const items = loadItems();
+    const item = items.find((i) => i.id === 'optional_item');
+    expect(item?.price_hint).toBe('kostenlos');
+    expect(item?.coords).toEqual({ lat: 1, lon: 2 });
+    const google = item?.links?.find((l) => l.url.includes('google.com'));
+    expect(google).toBeTruthy();
+    expect(item?.tags).toEqual(['a', 'b']);
   });
 });
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,50 +15,88 @@ export default function Page() {
           </a>
         ))}
       </nav>
-      {items.map((item) => (
-        <section
-          key={item.id}
-          id={item.id}
-          className="mb-12 rounded-lg bg-[#2a2a2a] p-6 shadow"
-        >
-          <h2 className="mb-4 text-2xl font-bold text-accent">{item.name}</h2>
-          <img
-            src={item.image}
-            alt={item.name}
-            width={800}
-            height={400}
-            loading="lazy"
-            className="mb-4 h-auto w-full rounded"
-          />
-          <p className="mb-2 text-foreground">{item.description}</p>
-          <p className="mb-2">
-            <strong>Planung:</strong> {item.planning}
-          </p>
-          <p className="mb-2">
-            <strong>Organisation:</strong> {item.organizing}
-          </p>
-          <p className="mb-2">
-            <strong>Fahrtzeit:</strong> {item.drive_min} Min.
-          </p>
-          <p className="mb-2">
-            <strong>Kategorie:</strong> {item.category.join(', ')}
-          </p>
-          <ul className="list-inside list-disc">
-            {item.links.map((l) => (
-              <li key={l.url}>
-                <a
-                  href={l.url}
-                  className="rounded px-1 text-accent underline hover:bg-accent hover:text-background"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {l.title}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </section>
-      ))}
+      {items.map((item) => {
+        const links = [...(item.links ?? [])];
+        return (
+          <section
+            key={item.id}
+            id={item.id}
+            className="mb-12 rounded-lg bg-[#2a2a2a] p-6 shadow"
+          >
+            <h2 className="mb-4 text-2xl font-bold text-accent">{item.name}</h2>
+            {item.image && (
+              <img
+                src={item.image}
+                alt={item.name}
+                width={800}
+                height={400}
+                loading="lazy"
+                className="mb-4 h-auto w-full rounded"
+              />
+            )}
+            {item.description && (
+              <p className="mb-2 text-foreground">{item.description}</p>
+            )}
+            {(item.planning_tips || item.planning) && (
+              <p className="mb-2">
+                <strong>Planung:</strong> {item.planning_tips ?? item.planning}
+              </p>
+            )}
+            {(item.organizing_tips || item.organizing) && (
+              <p className="mb-2">
+                <strong>Organisation:</strong> {item.organizing_tips ?? item.organizing}
+              </p>
+            )}
+            {(item.drive_time_min !== undefined || item.drive_min !== undefined) && (
+              <p className="mb-2">
+                <strong>Fahrtzeit:</strong> {item.drive_time_min ?? item.drive_min} Min.
+              </p>
+            )}
+            {item.duration_suggested_min !== undefined && (
+              <p className="mb-2">
+                <strong>Dauer:</strong> {item.duration_suggested_min} Min.
+              </p>
+            )}
+            {item.price_hint && (
+              <p className="mb-2">
+                <strong>Preis:</strong> {item.price_hint}
+              </p>
+            )}
+            {item.coords && (
+              <p className="mb-2">
+                <strong>Koordinaten:</strong> {item.coords.lat}, {item.coords.lon}
+              </p>
+            )}
+            {item.category && (
+              <p className="mb-2">
+                <strong>Kategorie:</strong>{' '}
+                {Array.isArray(item.category) ? item.category.join(', ') : item.category}
+              </p>
+            )}
+            {item.tags && item.tags.length > 0 && (
+              <p className="mb-2">
+                <strong>Tags:</strong> {item.tags.join(', ')}
+              </p>
+            )}
+            {links.length > 0 && (
+              <ul className="list-inside list-disc">
+                {links.map((l) => (
+                  <li key={l.url}>
+                    <a
+                      href={l.url}
+                      className="rounded px-1 text-accent underline hover:bg-accent hover:text-background"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {l.title}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        );
+      })}
     </main>
   );
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint",
-    "test:unit": "jest __tests__/maxpain.test.ts",
+    "test:unit": "jest __tests__/maxpain.test.ts __tests__/trips.test.ts",
     "test:integration": "jest __tests__/api.test.ts",
     "test:perf": "jest __tests__/perf.test.ts",
     "quality": "node quality.js"


### PR DESCRIPTION
## Summary
- extend trip item model to keep optional metadata and map URLs
- render all available place info such as planning tips, durations, price hints, coordinates and tags
- verify optional-field handling with new unit tests and include them in the unit test script

## Testing
- `pnpm build`
- `pnpm test:unit`
- `pnpm test:integration`
- `pnpm test:perf`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c8335636d4832192f7830cd7e02c3c