### PR TITLE
Fix sticky navigation overflow on small screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,11 @@ const scenicTrips = items.filter((item) => item.tags?.includes('Strand'));
 ```
 
 `loadItems` clones the dataset on each call in O(n) time, so mutating `items` does not impact subsequent renders.
+
+```tsx
+<nav className="flex w-full items-center gap-3 overflow-x-auto rounded-full flex-nowrap lg:flex-wrap">
+  {/* Trip shortcuts */}
+</nav>
+```
+
+The horizontal overflow keeps the sticky navigation compact on small screens while preserving wrapped chips on larger viewports.

--- a/__tests__/page.test.tsx
+++ b/__tests__/page.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => React.createElement('img', props),
+}));
+
+const mockItems = [
+  {
+    id: 'pisa',
+    name: 'Pisa – Piazza dei Miracoli',
+    category: 'Stadt',
+    links: [
+      { title: 'Tourismus Pisa', url: 'https://www.turismo.pisa.it/' },
+    ],
+  },
+  {
+    id: 'florence',
+    name: 'Florenz kompakt',
+    category: 'Stadt',
+    links: [],
+  },
+];
+
+jest.mock('@/lib/trips', () => ({
+  __esModule: true,
+  loadItems: jest.fn(() => mockItems),
+}));
+
+describe('Page navigation layout', () => {
+  beforeEach(() => {
+    const { loadItems } = jest.requireMock('@/lib/trips') as { loadItems: jest.Mock };
+    loadItems.mockReturnValue(mockItems);
+  });
+
+  it('enables horizontal scrolling to avoid wrapped sticky navigation', async () => {
+    const Page = (await import('@/app/page')).default;
+    const html = renderToStaticMarkup(React.createElement(Page));
+    expect(html).toContain('overflow-x-auto');
+    expect(html).toContain('flex-nowrap');
+    expect(html).toContain('lg:flex-wrap');
+  });
+
+  it('adds scroll margin so anchored cards remain readable beneath the sticky nav', async () => {
+    const Page = (await import('@/app/page')).default;
+    const html = renderToStaticMarkup(React.createElement(Page));
+    expect(html).toContain('scroll-mt-40');
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -52,7 +52,9 @@ export default function Page() {
           </dl>
         </div>
       </header>
-      <nav className="sticky top-6 z-20 flex flex-wrap items-center gap-3 rounded-full bg-[#0f172a99] p-4 shadow-xl backdrop-blur">
+      <nav
+        className="sticky top-6 z-20 flex w-full items-center gap-3 overflow-x-auto rounded-full bg-[#0f172a99] p-4 shadow-xl backdrop-blur flex-nowrap lg:flex-wrap"
+      >
         {items.map((item) => (
           <a
             key={item.id}
@@ -72,7 +74,7 @@ export default function Page() {
             <article
               key={item.id}
               id={item.id}
-              className="glass-panel relative flex flex-col gap-5 overflow-hidden rounded-3xl border border-transparent p-6 transition hover:border-[var(--accent)] hover:shadow-[0_24px_60px_rgba(8,12,21,0.7)]"
+              className="glass-panel relative flex flex-col gap-5 overflow-hidden rounded-3xl border border-transparent p-6 transition hover:border-[var(--accent)] hover:shadow-[0_24px_60px_rgba(8,12,21,0.7)] scroll-mt-40"
             >
               <div className="space-y-4">
                 <div className="flex flex-wrap items-center justify-between gap-3">

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint",
-    "test:unit": "jest __tests__/maxpain.test.ts __tests__/trips.test.ts",
+    "test:unit": "jest __tests__/maxpain.test.ts __tests__/trips.test.ts __tests__/page.test.tsx",
     "test:integration": "jest __tests__/api.test.ts",
     "test:perf": "jest __tests__/perf.test.ts",
     "quality": "node quality.js"


### PR DESCRIPTION
## Summary
- prevent the sticky navigation from filling the viewport by enforcing horizontal scrolling on small screens and adding anchor scroll margin
- add a regression test for the navigation classes and document the sticky nav usage pattern

## Testing
- pnpm test:unit
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c865d7062483219ae96bc6322a8c38