### PR TITLE
Add cached image proxy for remote trip photos

### DIFF
--- a/__tests__/image-config.test.ts
+++ b/__tests__/image-config.test.ts
@@ -1,11 +1,18 @@
-import config from '../next.config';
+import { buildImageProxyUrl, isAllowedImageHost } from '@/lib/image-proxy';
 
-describe('image remotePatterns configuration', () => {
-  it('allows wikimedia and unsplash', () => {
-    const patterns = config.images?.remotePatterns ?? [];
-    const hosts = patterns.map((p) => p.hostname);
-    expect(hosts).toEqual(
-      expect.arrayContaining(['upload.wikimedia.org', 'images.unsplash.com'])
-    );
+describe('image proxy helpers', () => {
+  it('builds a proxied url with encoded source', () => {
+    const url = 'https://upload.wikimedia.org/test image.jpg';
+    const proxy = buildImageProxyUrl(url);
+    const parsed = new URL(proxy, 'http://localhost');
+    expect(parsed.pathname).toBe('/api/image');
+    expect(parsed.searchParams.get('src')).toBe(url);
+    expect(parsed.searchParams.has('v')).toBe(true);
+  });
+
+  it('only allows whitelisted hosts', () => {
+    expect(isAllowedImageHost(new URL('https://upload.wikimedia.org/foo.jpg'))).toBe(true);
+    expect(isAllowedImageHost(new URL('https://images.unsplash.com/photo.jpg'))).toBe(true);
+    expect(isAllowedImageHost(new URL('https://example.com/bar.jpg'))).toBe(false);
   });
 });

--- a/app/api/image/route.ts
+++ b/app/api/image/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest } from 'next/server';
+import { Buffer } from 'buffer';
+import { isAllowedImageHost } from '@/lib/image-proxy';
+import { CachedImage, getCachedImage, setCachedImage } from '@/lib/server/image-cache';
+
+const MAX_IMAGE_BYTES = 2_500_000; // 2.5 MB upper bound per image
+const CACHE_CONTROL_HEADER = 'public, max-age=86400, stale-while-revalidate=604800';
+
+function buildErrorResponse(message: string, status = 400): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+async function fetchRemoteImage(src: string): Promise<CachedImage> {
+  const response = await fetch(src, {
+    headers: {
+      Accept: 'image/avif,image/webp,image/*,*/*;q=0.8',
+    },
+    cache: 'no-store',
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to load image: ${response.status} ${response.statusText}`);
+  }
+  const contentType = response.headers.get('content-type') ?? 'application/octet-stream';
+  const arrayBuffer = await response.arrayBuffer();
+  if (arrayBuffer.byteLength > MAX_IMAGE_BYTES) {
+    throw new Error('Image too large to cache');
+  }
+  const data = Buffer.from(arrayBuffer);
+  return {
+    contentType,
+    data,
+    createdAt: Date.now(),
+  };
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const src = request.nextUrl.searchParams.get('src');
+  if (!src) {
+    return buildErrorResponse('Missing src query parameter');
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(src);
+  } catch {
+    return buildErrorResponse('Invalid image URL');
+  }
+
+  if (!isAllowedImageHost(parsed)) {
+    return buildErrorResponse('Host not allowed');
+  }
+
+  try {
+    const cached = await getCachedImage(src);
+    if (cached) {
+      return new Response(cached.data, {
+        status: 200,
+        headers: {
+          'content-type': cached.contentType,
+          'cache-control': CACHE_CONTROL_HEADER,
+        },
+      });
+    }
+
+    const fresh = await fetchRemoteImage(src);
+    await setCachedImage(src, fresh);
+    return new Response(fresh.data, {
+      status: 200,
+      headers: {
+        'content-type': fresh.contentType,
+        'cache-control': CACHE_CONTROL_HEADER,
+      },
+    });
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.error('Image proxy failed', error);
+    }
+    return buildErrorResponse('Unable to load image', 502);
+  }
+}
+
+export const runtime = 'nodejs';
+export const preferredRegion = 'auto';
+
+export const dynamic = 'force-dynamic';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import { buildImageProxyUrl } from '@/lib/image-proxy';
 import { loadItems } from '@/lib/trips';
 import type { Item } from '@/lib/trips';
 
@@ -95,7 +96,7 @@ export default function Page() {
                 {item.image && (
                   <div className="overflow-hidden rounded-2xl border border-[var(--card-border)]">
                     <Image
-                      src={item.image}
+                      src={buildImageProxyUrl(item.image)}
                       alt={item.name}
                       width={800}
                       height={400}

--- a/lib/image-proxy.ts
+++ b/lib/image-proxy.ts
@@ -1,0 +1,35 @@
+import crypto from 'crypto';
+
+/** Allowed remote hosts that can be proxied through the image handler. */
+export const ALLOWED_IMAGE_HOSTS = Object.freeze([
+  'upload.wikimedia.org',
+  'images.unsplash.com',
+]);
+
+const CACHE_BUSTER = crypto.createHash('sha1').update(process.env.NODE_ENV ?? 'development').digest('hex').slice(0, 8);
+
+/**
+ * Build a deterministic cache key for an image source URL. Runs in O(n) time
+ * where n is the length of the source string because it hashes every
+ * character exactly once.
+ */
+export function buildImageCacheKey(src: string): string {
+  return crypto.createHash('sha256').update(src).digest('hex');
+}
+
+/**
+ * Construct the API route used to proxy and cache remote images.
+ */
+export function buildImageProxyUrl(src: string): string {
+  const params = new URLSearchParams({ src, v: CACHE_BUSTER });
+  return `/api/image?${params.toString()}`;
+}
+
+/**
+ * Validate that a URL targets an allowed host so we avoid SSRF issues when
+ * proxying remote images. The check runs in O(m) time where m is the hostname
+ * length.
+ */
+export function isAllowedImageHost(url: URL): boolean {
+  return ALLOWED_IMAGE_HOSTS.includes(url.hostname);
+}

--- a/lib/server/image-cache.ts
+++ b/lib/server/image-cache.ts
@@ -1,0 +1,107 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { Buffer } from 'buffer';
+import { buildImageCacheKey } from '@/lib/image-proxy';
+
+export interface CachedImage {
+  readonly data: Buffer;
+  readonly contentType: string;
+  readonly createdAt: number;
+}
+
+const CACHE_TTL_MS = 1000 * 60 * 60 * 24; // 24 hours
+const CACHE_ROOT = path.join(process.cwd(), '.next', 'cache', 'image-proxy');
+
+const memoryCache = new Map<string, CachedImage>();
+
+function isExpired(entry: CachedImage): boolean {
+  return Date.now() - entry.createdAt > CACHE_TTL_MS;
+}
+
+function cachePathForSource(src: string): string {
+  const key = buildImageCacheKey(src);
+  return path.join(CACHE_ROOT, `${key}.json`);
+}
+
+async function ensureCacheDir(): Promise<void> {
+  await fs.mkdir(CACHE_ROOT, { recursive: true }).catch((error: unknown) => {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+      throw error;
+    }
+  });
+}
+
+async function readFromDisk(src: string): Promise<CachedImage | null> {
+  try {
+    const file = cachePathForSource(src);
+    const raw = await fs.readFile(file, 'utf8');
+    const parsed = JSON.parse(raw) as { contentType: string; data: string; createdAt: number };
+    const entry: CachedImage = {
+      contentType: parsed.contentType,
+      data: Buffer.from(parsed.data, 'base64'),
+      createdAt: parsed.createdAt,
+    };
+    if (isExpired(entry)) {
+      await fs.unlink(file).catch(() => {});
+      return null;
+    }
+    memoryCache.set(src, entry);
+    return entry;
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === 'ENOENT') {
+      return null;
+    }
+    if (err.name === 'SyntaxError') {
+      // Corrupt cache entry – delete and skip.
+      try {
+        await fs.unlink(cachePathForSource(src));
+      } catch {
+        // ignore cleanup failures
+      }
+      return null;
+    }
+    throw err;
+  }
+}
+
+async function writeToDisk(src: string, entry: CachedImage): Promise<void> {
+  const file = cachePathForSource(src);
+  const payload = JSON.stringify({
+    contentType: entry.contentType,
+    createdAt: entry.createdAt,
+    data: entry.data.toString('base64'),
+  });
+  await ensureCacheDir();
+  await fs.writeFile(file, payload, 'utf8');
+}
+
+export async function getCachedImage(src: string): Promise<CachedImage | null> {
+  const existing = memoryCache.get(src);
+  if (existing && !isExpired(existing)) {
+    return existing;
+  }
+  memoryCache.delete(src);
+  return readFromDisk(src);
+}
+
+export async function setCachedImage(src: string, entry: CachedImage): Promise<void> {
+  memoryCache.set(src, entry);
+  try {
+    await writeToDisk(src, entry);
+  } catch (error) {
+    // Ignore write errors (e.g., read-only file systems)
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('Failed to persist image cache entry:', error);
+    }
+  }
+}
+
+export async function clearImageCache(): Promise<void> {
+  memoryCache.clear();
+  try {
+    await fs.rm(CACHE_ROOT, { recursive: true, force: true });
+  } catch {
+    // ignore cleanup failures
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint",
-    "test:unit": "jest __tests__/maxpain.test.ts __tests__/trips.test.ts __tests__/page.test.tsx",
+    "test:unit": "jest __tests__/maxpain.test.ts __tests__/trips.test.ts __tests__/page.test.tsx __tests__/image-config.test.ts __tests__/image-route.test.ts",
     "test:integration": "jest __tests__/api.test.ts",
     "test:perf": "jest __tests__/perf.test.ts",
     "quality": "node quality.js"


### PR DESCRIPTION
## Summary
- add an API route that fetches remote trip images, caches them, and serves them without committing binary assets
- add shared helpers to build proxied URLs and reuse host validation from the page component
- cover the proxy with unit tests and run the full quality suite

## Testing
- pnpm quality

------
https://chatgpt.com/codex/tasks/task_e_68c94ce2229c8321a7064f05c3cd3ece