### PR TITLE
Fix image response body type for proxy cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,11 @@ const scenicTrips = items.filter((item) => item.tags?.includes('Strand'));
 ```
 
 The horizontal overflow keeps the sticky navigation compact on small screens while preserving wrapped chips on larger viewports.
+
+```ts
+const remoteUrl = 'https://upload.wikimedia.org/path/to/image.jpg';
+const response = await fetch(`/api/image?src=${encodeURIComponent(remoteUrl)}`);
+const cachedBlob = await response.blob();
+```
+
+The proxy validates hosts in O(1) time and returns cached binaries with long-lived cache headers for CDNs.

--- a/__tests__/image-route.test.ts
+++ b/__tests__/image-route.test.ts
@@ -47,12 +47,16 @@ describe('image proxy route', () => {
     const firstRequest = new NextRequest(`http://localhost/api/image?src=${encodeURIComponent(url)}`);
     const first = await GET(firstRequest);
     expect(first.status).toBe(200);
-    expect(Buffer.from(await first.arrayBuffer())).toEqual(buffer);
+    const firstBody = await first.arrayBuffer();
+    expect(firstBody).toBeInstanceOf(ArrayBuffer);
+    expect(Buffer.from(firstBody)).toEqual(buffer);
 
     const secondRequest = new NextRequest(`http://localhost/api/image?src=${encodeURIComponent(url)}`);
     const second = await GET(secondRequest);
     expect(second.status).toBe(200);
-    expect(Buffer.from(await second.arrayBuffer())).toEqual(buffer);
+    const secondBody = await second.arrayBuffer();
+    expect(secondBody).toBeInstanceOf(ArrayBuffer);
+    expect(Buffer.from(secondBody)).toEqual(buffer);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/api/image/route.ts
+++ b/app/api/image/route.ts
@@ -13,6 +13,10 @@ function buildErrorResponse(message: string, status = 400): Response {
   });
 }
 
+function bufferToArrayBuffer(buffer: Buffer): ArrayBuffer {
+  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+}
+
 async function fetchRemoteImage(src: string): Promise<CachedImage> {
   const response = await fetch(src, {
     headers: {
@@ -56,7 +60,7 @@ export async function GET(request: NextRequest): Promise<Response> {
   try {
     const cached = await getCachedImage(src);
     if (cached) {
-      return new Response(cached.data, {
+      return new Response(bufferToArrayBuffer(cached.data), {
         status: 200,
         headers: {
           'content-type': cached.contentType,
@@ -67,7 +71,7 @@ export async function GET(request: NextRequest): Promise<Response> {
 
     const fresh = await fetchRemoteImage(src);
     await setCachedImage(src, fresh);
-    return new Response(fresh.data, {
+    return new Response(bufferToArrayBuffer(fresh.data), {
       status: 200,
       headers: {
         'content-type': fresh.contentType,


### PR DESCRIPTION
## Summary
- convert cached image buffers to ArrayBuffer before building responses to satisfy Next.js type expectations
- assert array buffer bodies inside image route tests to guard regression
- document how to consume the image proxy endpoint with a short example

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68c9509c7f1c8321b454bd77f46d843f