### PR TITLE
docs: refresh vibe scaffolding

### DIFF
--- a/__tests__/docs.test.ts
+++ b/__tests__/docs.test.ts
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('vibe documentation scaffolding', () => {
+  const root = path.resolve(__dirname, '..');
+
+  function read(file: string): string {
+    const fullPath = path.join(root, file);
+    if (!fs.existsSync(fullPath)) {
+      throw new Error(`Expected ${file} to exist at ${fullPath}`);
+    }
+    return fs.readFileSync(fullPath, 'utf-8');
+  }
+
+  it('ensures prompt.md exposes the latest core sections', () => {
+    const prompt = read('prompt.md');
+    const requiredHeadings = [
+      '## Objective',
+      '## Deliverables',
+      '## Tone and Copy',
+      '## Visual Language',
+      '## Data + APIs',
+      '## Interactions',
+      '## Technical Guardrails',
+      '## Out of Scope',
+    ];
+    for (const heading of requiredHeadings) {
+      expect(prompt).toContain(heading);
+    }
+  });
+
+  it('describes the data contract and usage example in reader.md', () => {
+    const reader = read('reader.md');
+    expect(reader).toContain('## Data Sources');
+    expect(reader).toContain('## Usage Example');
+    expect(reader).toMatch(/const shortDrives = items\.filter/);
+  });
+
+  it('tracks progress and risks in status.md', () => {
+    const status = read('status.md');
+    expect(status).toContain('## Active Work');
+    expect(status).toContain('[x] Drafted updated prompt');
+    expect(status).toContain('## Risks');
+    expect(status).toContain('## Decisions');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint",
-    "test:unit": "jest __tests__/maxpain.test.ts __tests__/trips.test.ts __tests__/page.test.tsx __tests__/image-config.test.ts __tests__/image-route.test.ts",
+    "test:unit": "jest __tests__/maxpain.test.ts __tests__/trips.test.ts __tests__/page.test.tsx __tests__/image-config.test.ts __tests__/image-route.test.ts __tests__/docs.test.ts",
     "test:integration": "jest __tests__/api.test.ts",
     "test:perf": "jest __tests__/perf.test.ts",
     "quality": "node quality.js"

--- a/prompt.md
+++ b/prompt.md
@@ -1,0 +1,41 @@
+# v0 Prompt: BTC Max-Pain Dashboard
+
+## Objective
+- Craft generative UI updates for the BTC max-pain planner that merge quant finance clarity with premium travel storytelling.
+- Preserve the trip discovery flow: hero summary, sticky chip navigation, and stacked glass panels for itinerary cards.
+- Keep responses deterministic, production-ready, and compliant with Next.js 15 + Tailwind conventions already in the repo.
+
+## Deliverables
+- Updated or new React Server Components under `app/` with Tailwind utility classes and existing `glass-panel` aesthetic.
+- Re-usable helper functions in `lib/` when data shaping is required; never fetch directly from components.
+- Copy deck variants (headline, body, CTA) tailored for German-speaking travelers following the calm-but-confident brand voice.
+
+## Tone and Copy
+- Voice: pragmatic, empathetic, quietly enthusiastic about road trips.
+- Style: short paragraphs, avoid slang, include concrete hints (distance, timing, booking windows).
+- Localize units to metric, currency to EUR where needed, and show warnings when data is missing.
+
+## Visual Language
+- Respect the dark glassmorphism palette defined in `app/globals.css` (accent `#f97316`, muted slate typography).
+- Use rounded-3xl corners, layered gradients, and soft drop shadows consistent with existing hero + card layout.
+- Prefer responsive flex/grid combos that keep sticky navigation usable on touch devices.
+
+## Data + APIs
+- Source trip content via `loadItems()` / `loadTrips()` from `lib/trips.ts`; never bypass caching logic.
+- Highlight key derived stats (count, categories, max drive) in O(n) aggregations only.
+- Guard against empty data by surfacing fallback messaging and ensuring deterministic ordering by popularity.
+
+## Interactions
+- Keep sticky chip navigation accessible (keyboard focus, ARIA labels on icons as needed).
+- Offer CTA buttons linking to Apple/Google Maps when `links` exist; degrade gracefully if URLs are absent.
+- Allow optional filters (tags, drive time) without mutating shared state; derive filtered arrays per render.
+
+## Technical Guardrails
+- Only use server-safe APIs in Server Components; shift client behavior into isolated Client Components when necessary.
+- Avoid experimental dependencies; stick to built-in Next.js routing, fetch, and caching utilities.
+- Target O(n) data passes, pre-validate user input, and never rely on `eval`/`Function` or untrusted HTML.
+
+## Out of Scope
+- Payment, authentication, or booking integrations.
+- Map renderers, 3D globe effects, or heavy canvas work.
+- Altering deployment scripts or cron configuration unless explicitly requested.

--- a/reader.md
+++ b/reader.md
@@ -1,0 +1,30 @@
+# Reader: Montescudaio Roadbook
+
+## Product Snapshot
+- **Purpose:** Curated day-trip planner that prioritizes stress-free BTC-funded getaways around Montescudaio.
+- **Users:** Travel-savvy planners who expect precise guidance (drive time, ticketing, navigation links) in German.
+- **Value:** Aggregates Deribit-inspired discipline with concierge-level editorial curation inside a single scrolling view.
+
+## Data Sources
+- Primary JSON datasets live in `data/*.json` with the bundled fallback defined in `data/static-trips.ts`.
+- Loader utilities (`loadTrips`, `loadItems`) clone data defensively to preserve immutability and maintain O(n) complexity per request.
+- Apple/Google Maps links are synthesized in `lib/trips.ts`; keep new data aligned with the `Item` interface.
+
+## Architecture Overview
+- Next.js 15 App Router with a single page composed of server components, styled via Tailwind + custom CSS tokens.
+- Shared UI idioms: `glass-panel` shells, sticky horizontal filters, card hover glow, and accent-forward CTAs.
+- Image proxying handled through `/lib/image-proxy` and `/api/image` to whitelist hosts and supply cached responses.
+
+## Usage Example
+```ts
+import { loadItems } from '@/lib/trips';
+
+const items = loadItems();
+const shortDrives = items.filter((item) => (item.drive_time_min ?? item.drive_min ?? 0) <= 45);
+```
+The helper runs in O(n) time, returns cloned objects, and leaves the shared dataset untouched so UI interactions stay deterministic.
+
+## Extension Ideas
+- Introduce a client-side tag filter that mirrors the sticky chip styling and respects keyboard navigation.
+- Add analytics-safe tracking for link clicks by wrapping anchors in a lightweight client component.
+- Offer localized print/PDF exports that keep the hero summary and cards readable in monochrome.

--- a/status.md
+++ b/status.md
@@ -1,0 +1,17 @@
+# Build Status
+
+## Active Work
+- [x] Drafted updated prompt, reader, and status docs aligned with v0 vibe-coding conventions.
+- [ ] Validate documentation against future design prompts in staging before rollout.
+
+## Upcoming
+- [ ] Prototype optional tag/drive-time filters as client components respecting current data immutability.
+- [ ] Evaluate localized copy variants (EN/IT) once German baseline is approved.
+
+## Risks
+- Documentation drift if Tailwind tokens or layout primitives change without synchronized updates.
+- Rate limit spikes from Deribit API may require clarifying fallback messaging in the prompt.
+
+## Decisions
+- Keep chip navigation sticky with current shadow treatment to preserve recognisable brand feel.
+- Prioritize deterministic data loaders over real-time fetches to stay Vercel hobby-tier friendly.


### PR DESCRIPTION
## Summary
- add v0-style prompt, reader, and status documentation that encode the desired product voice and guardrails
- add a Jest regression test ensuring the new documentation keeps core sections intact
- update the unit test script so the docs check runs with the existing suite

## Testing
- pnpm test:unit

------
https://chatgpt.com/codex/tasks/task_e_68c964c91e7c83218db22621bf805c26