### PR TITLE
Ensure trip imagery uses allowlisted sources

### DIFF
--- a/__tests__/trips.test.ts
+++ b/__tests__/trips.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { appleMapsAppUrl, appleMapsLink, loadItems } from '@/lib/trips';
+import { ALLOWED_IMAGE_HOSTS } from '@/lib/image-proxy';
 
 describe('loadItems', () => {
   const dataDir = path.join(process.cwd(), 'data');
@@ -120,6 +121,25 @@ describe('loadItems', () => {
     const appleApp = item?.links?.find((l) => l.url.startsWith('maps://?q=1,2'));
     expect(appleApp).toBeTruthy();
     expect(item?.tags).toEqual(['a', 'b']);
+  });
+
+  it('only references images from allowed hosts', () => {
+    const items = loadItems();
+    const invalid = items
+      .filter((item) => Boolean(item.image))
+      .filter((item) => {
+        if (!item.image) {
+          return false;
+        }
+        try {
+          const host = new URL(item.image).hostname;
+          return !ALLOWED_IMAGE_HOSTS.includes(host);
+        } catch {
+          return true;
+        }
+      })
+      .map((item) => item.id);
+    expect(invalid).toEqual([]);
   });
 });
 

--- a/data/montescudaio.json
+++ b/data/montescudaio.json
@@ -72,7 +72,7 @@
         {"title": "WØM FEST – Instagram", "url": "https://www.instagram.com/wom_fest/"},
         {"title": "Lucca What's On – Kalender", "url": "https://www.luccawhatson.com/calendar/wom-fest-1"}
       ],
-      "image": "https://images.unsplash.com/photo-1516280030429-27679b3dc9cf?q=80&w=1400&auto=format&fit=crop",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/Blastema_live_2011.jpg/1024px-Blastema_live_2011.jpg",
       "map_query": "Distilleria Indie San Pietro in Campo Barga"
     },
     {


### PR DESCRIPTION
## Summary
- swap the Montescudaio indie festival card to a Wikimedia Commons photo so the proxy can serve a reliable image
- add a regression test that verifies every trip dataset image URL stays on the approved allowlist

## Testing
- pnpm test:unit
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c96808dd7c832193f291ee01853932