### PR TITLE
Switch Montescudaio imagery to remote sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,16 @@ provides driving directions in CarPlay and is derived from `map_query`.
       "url": "https://maps.apple.com/?daddr=Example%20Place&dirflg=d"
     }
   ],
-  "image": "https://example.com/image.jpg",
+  "image": "https://upload.wikimedia.org/path/to/example.jpg",
   "map_query": "Example Place"
 }
 ```
+
+Source representative hero images from authoritative ticketing pages or open
+media libraries (e.g., Wikimedia Commons). Only use hosts listed in
+`ALLOWED_IMAGE_HOSTS`; the UI automatically proxies them via `/api/image` and
+caches the response on first request. When you need a new host, add it to the
+allow-list and document the license in the dataset comment.
 
 ## Usage Example
 
@@ -83,9 +89,10 @@ const scenicTrips = items.filter((item) => item.tags?.includes('Strand'));
 The horizontal overflow keeps the sticky navigation compact on small screens while preserving wrapped chips on larger viewports.
 
 ```ts
-const remoteUrl = 'https://upload.wikimedia.org/path/to/image.jpg';
-const response = await fetch(`/api/image?src=${encodeURIComponent(remoteUrl)}`);
-const cachedBlob = await response.blob();
+import { resolveImageSrc } from '@/lib/image-proxy';
+
+const remoteSrc = resolveImageSrc('https://upload.wikimedia.org/path/to/image.jpg');
 ```
 
-The proxy validates hosts in O(1) time and returns cached binaries with long-lived cache headers for CDNs.
+`resolveImageSrc` trims sources in O(n) time and proxies approved hosts through
+the cached API route so deployments fetch and persist imagery post-deploy.

--- a/__tests__/image-config.test.ts
+++ b/__tests__/image-config.test.ts
@@ -1,4 +1,9 @@
-import { buildImageProxyUrl, isAllowedImageHost } from '@/lib/image-proxy';
+import {
+  buildImageProxyUrl,
+  isAllowedImageHost,
+  isRemoteImageSource,
+  resolveImageSrc,
+} from '@/lib/image-proxy';
 
 describe('image proxy helpers', () => {
   it('builds a proxied url with encoded source', () => {
@@ -14,5 +19,20 @@ describe('image proxy helpers', () => {
     expect(isAllowedImageHost(new URL('https://upload.wikimedia.org/foo.jpg'))).toBe(true);
     expect(isAllowedImageHost(new URL('https://images.unsplash.com/photo.jpg'))).toBe(true);
     expect(isAllowedImageHost(new URL('https://example.com/bar.jpg'))).toBe(false);
+  });
+
+  it('detects remote image sources', () => {
+    expect(isRemoteImageSource('https://upload.wikimedia.org/foo.jpg')).toBe(true);
+    expect(isRemoteImageSource('HTTP://images.unsplash.com/photo.jpg')).toBe(true);
+    expect(isRemoteImageSource('/images/montescudaio/pisa.jpg')).toBe(false);
+    expect(isRemoteImageSource('images/montescudaio/pisa.jpg')).toBe(false);
+  });
+
+  it('normalizes image sources for rendering', () => {
+    const remote = 'https://upload.wikimedia.org/foo.jpg';
+    expect(resolveImageSrc(remote)).toContain('/api/image');
+    expect(resolveImageSrc('/images/example.jpg')).toBe('/images/example.jpg');
+    expect(resolveImageSrc('images/example.jpg')).toBe('/images/example.jpg');
+    expect(() => resolveImageSrc('   ')).toThrow('Image source must be a non-empty string');
   });
 });

--- a/__tests__/trips.test.ts
+++ b/__tests__/trips.test.ts
@@ -6,6 +6,7 @@ import { ALLOWED_IMAGE_HOSTS } from '@/lib/image-proxy';
 describe('loadItems', () => {
   const dataDir = path.join(process.cwd(), 'data');
   const tempFile = path.join(dataDir, 'temp_test.json');
+  const publicDir = path.join(process.cwd(), 'public');
 
   afterEach(() => {
     jest.restoreAllMocks();
@@ -123,13 +124,17 @@ describe('loadItems', () => {
     expect(item?.tags).toEqual(['a', 'b']);
   });
 
-  it('only references images from allowed hosts', () => {
+  it('only references images from allowed hosts or bundled assets', () => {
     const items = loadItems();
     const invalid = items
       .filter((item) => Boolean(item.image))
       .filter((item) => {
         if (!item.image) {
           return false;
+        }
+        if (item.image.startsWith('/')) {
+          const diskPath = path.join(publicDir, item.image.replace(/^\/+/, ''));
+          return !fs.existsSync(diskPath);
         }
         try {
           const host = new URL(item.image).hostname;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { buildImageProxyUrl } from '@/lib/image-proxy';
+import { resolveImageSrc } from '@/lib/image-proxy';
 import { loadItems } from '@/lib/trips';
 import type { Item } from '@/lib/trips';
 
@@ -96,7 +96,7 @@ export default function Page() {
                 {item.image && (
                   <div className="overflow-hidden rounded-2xl border border-[var(--card-border)]">
                     <Image
-                      src={buildImageProxyUrl(item.image)}
+                      src={resolveImageSrc(item.image)}
                       alt={item.name}
                       width={800}
                       height={400}

--- a/data/montescudaio.json
+++ b/data/montescudaio.json
@@ -20,7 +20,7 @@
         {"title": "Ticket-Hinweise (OPA)", "url": "https://www.opapisa.it/en/tickets/a-few-words-of-advice-before-you-buy-your-ticket/"},
         {"title": "Shuttle P+R Pietrasantina (Comune Pisa)", "url": "https://www.turismo.pisa.it/en/servizio/Shuttle-bus-Park-Pietrasantina-Lungarni-Bus-25"}
       ],
-      "image": "https://upload.wikimedia.org/wikipedia/commons/4/4e/Pisa_-_Duomo_Baptistery_CampoSanto_Leaning_Tower.jpg",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/5/5f/The_Duomo_and_Tower_of_Pisa_at_sunrise.jpg",
       "apple_maps_url": "https://maps.apple.com/?ll=43.7230,10.3966&q=Leaning%20Tower%20of%20Pisa",
       "map_query": "Pietrasantina Parking Pisa"
     },
@@ -37,7 +37,7 @@
         {"title": "Uffizi – Tickets (offiziell)", "url": "https://www.uffizi.it/en/tickets"},
         {"title": "P+R Villa Costanza", "url": "https://parcheggiovillacostanza.it/it/"}
       ],
-      "image": "https://upload.wikimedia.org/wikipedia/commons/4/4c/Panorama_of_Piazza_della_Signoria%2C_Florence%2C_Italy_-_July_2006.jpg",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/4/49/Galleria_degli_Uffizi--w.jpg",
       "apple_maps_url": "https://maps.apple.com/?ll=43.7731,11.2556&q=Duomo%20di%20Firenze",
       "map_query": "Villa Costanza Parcheggio Scandicci"
     },
@@ -54,7 +54,7 @@
         {"title": "Comune Lucca – Info zu den Mauern", "url": "https://www.comune.lucca.it/vivere-il-comune/luoghi/le-mura-di-lucca-un-parco-urbano/"},
         {"title": "Tourismus Lucca – Bike Sharing", "url": "https://www.turismo.lucca.it/en/bike-sharing"}
       ],
-      "image": "https://upload.wikimedia.org/wikipedia/commons/4/47/Lucca_Mura_di_Lucca_2017.jpg",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/4/47/Lucca.city_walls01.jpg",
       "apple_maps_url": "https://maps.apple.com/?ll=43.8420,10.5050&q=Mura%20di%20Lucca",
       "map_query": "Le Mura di Lucca noleggio bici"
     },
@@ -72,7 +72,7 @@
         {"title": "WØM FEST – Instagram", "url": "https://www.instagram.com/wom_fest/"},
         {"title": "Lucca What's On – Kalender", "url": "https://www.luccawhatson.com/calendar/wom-fest-1"}
       ],
-      "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/Blastema_live_2011.jpg/1024px-Blastema_live_2011.jpg",
+      "image": "https://images.unsplash.com/photo-1701506516420-3ef4b27413c9?auto=format&fit=crop&w=1600&q=80",
       "map_query": "Distilleria Indie San Pietro in Campo Barga"
     },
     {
@@ -89,7 +89,7 @@
         {"title": "Visit Tuscany – Viale dei Cipressi", "url": "https://www.visittuscany.com/en/attractions/viale-cipressi-bolgheri/"},
         {"title": "Apple Maps – Bolgheri Dorf", "url": "https://maps.apple.com/?ll=43.2950,10.6140&q=Bolgheri"}
       ],
-      "image": "https://upload.wikimedia.org/wikipedia/commons/1/1d/Viale_dei_Cipressi_Bolgheri.jpg",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/f/ff/Viale_dei_Cipressi%2C_Bolgheri%2C_Castagneto_Carducci.JPG",
       "apple_maps_url": "https://maps.apple.com/?ll=43.3090,10.6075&q=Viale%20dei%20Cipressi",
       "map_query": "Viale dei Cipressi Bolgheri"
     },
@@ -105,7 +105,7 @@
       "links": [
         {"title": "Bandiera Blu 2025 – Elenco", "url": "https://www.bandierablu.org/common/blueflag.asp?anno=2025&tipo=bb"}
       ],
-      "image": "https://upload.wikimedia.org/wikipedia/commons/f/f8/Marina_di_Bibbona%2C_litorale.jpg",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/f/f2/Marina_di_Bibbona%2C_spiaggia_verso_sud.jpg",
       "apple_maps_url": "https://maps.apple.com/?ll=43.2350,10.5320&q=Marina%20di%20Bibbona",
       "map_query": "Marina di Bibbona spiaggia"
     },
@@ -122,7 +122,7 @@
         {"title": "CNR PDF – Bandiera Blu 2025 (Toscana-Liste inkl. Cecina)", "url": "https://www.cnr.it/it/news/allegato/3123"},
         {"title": "Visit Cecina – Barrierefreie Spiaggia (News)", "url": "https://www.visitcecina.com/liberamente-una-spiaggia-per-tutti/"}
       ],
-      "image": "https://upload.wikimedia.org/wikipedia/commons/5/5a/Cecina_Mare_lungomare.jpg",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/b/ba/Pineta_di_Le_Gorette%2C_Riserva_di_Tomboli%2C_Cecina.jpg",
       "apple_maps_url": "https://maps.apple.com/?ll=43.3028,10.4872&q=Cecina%20Mare",
       "map_query": "Le Gorette Cecina spiaggia"
     },
@@ -139,7 +139,7 @@
         {"title": "Acquario – Offizielle Seite (Prezzi/Biglietti)", "url": "https://www.acquariodilivorno.it/"},
         {"title": "Acquario – Orari/Avvisi", "url": "https://www.acquariodilivorno.it/aperture-e-orari"}
       ],
-      "image": "https://upload.wikimedia.org/wikipedia/commons/7/73/Terrazza_Mascagni_Livorno.jpg",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/c/ce/Terrazza_Mascagni_2008.jpg",
       "apple_maps_url": "https://maps.apple.com/?ll=43.5353,10.2930&q=Terrazza%20Mascagni",
       "map_query": "Terrazza Mascagni Livorno"
     },
@@ -156,7 +156,7 @@
         {"title": "Parchi Val di Cornia – Orari & Tariffe", "url": "https://www.parchivaldicornia.it/info-e-servizi/orari-e-tariffe/"},
         {"title": "Acropoli di Populonia", "url": "https://www.parchivaldicornia.it/parchi-archeologici/parco-archeologico-di-baratti-e-populonia/acropoli-di-populonia/"}
       ],
-      "image": "https://upload.wikimedia.org/wikipedia/commons/9/9c/Baratti_golfo.jpg",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/d/d3/Gulf_of_Baratti_from_Populonia_Alta%2C_Panorama.jpg",
       "apple_maps_url": "https://maps.apple.com/?ll=42.9590,10.5340&q=Populonia",
       "map_query": "Parco archeologico di Baratti e Populonia"
     },
@@ -172,7 +172,7 @@
       "links": [
         {"title": "Parchi Val di Cornia – Info/Calendario", "url": "https://www.parchivaldicornia.it/info-e-servizi/orari-e-tariffe/"}
       ],
-      "image": "https://upload.wikimedia.org/wikipedia/commons/2/29/Miniera_di_Valle_Genna%2C_Parco_archeominerario_di_San_Silvestro%2C_Campiglia_Marittima%2C_2018.jpg",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/a/aa/Parco_archeominerario_di_San_Silvestro_Path_from_Valle_dei_Lanzi_to_castle.jpg",
       "map_query": "Parco archeominerario di San Silvestro"
     },
     {
@@ -188,7 +188,7 @@
         {"title": "Terme di Casciana – Orari (offiziell)", "url": "https://www.termedicasciana.com/le-piscine/orari-di-apertura/"},
         {"title": "Terme – Kontakt/Reservierung", "url": "https://www.termedicasciana.com/"}
       ],
-      "image": "https://upload.wikimedia.org/wikipedia/commons/1/1d/Casciana_Terme_thermal_baths.jpg",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/9/9d/Casciana_terme.JPG",
       "map_query": "Terme di Casciana"
     },
     {
@@ -204,7 +204,7 @@
         {"title": "Calidario – Sorgente (Orari/Prezzi)", "url": "https://www.calidario.it/sorgente-naturale/"},
         {"title": "Calidario – Thermarium (prenota)", "url": "https://www.calidario.it/prodotto/thermarium-2/"}
       ],
-      "image": "https://upload.wikimedia.org/wikipedia/commons/1/1a/Calidario_Terme_Etrusche_-_Venturina.jpg",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/6/6f/Venturina_Calidario_2012-08-25_001.jpg",
       "apple_maps_url": "https://maps.apple.com/?ll=43.0248,10.6082&q=Calidario%20Terme%20Etrusche",
       "map_query": "Calidario Terme Etrusche"
     },
@@ -220,7 +220,7 @@
       "links": [
         {"title": "Volterra Turismo – Info & Parken", "url": "https://www.volterratur.it/"}
       ],
-      "image": "https://upload.wikimedia.org/wikipedia/commons/0/0a/Volterra_panorama_2012.jpg",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/2/27/Volterra_city.jpg",
       "apple_maps_url": "https://maps.apple.com/?ll=43.4010,10.8610&q=Volterra",
       "map_query": "Parcheggio La Dogana Volterra"
     },
@@ -236,7 +236,7 @@
       "links": [
         {"title": "Comune San Gimignano – Parken", "url": "https://www.comune.sangimignano.si.it/it/page/parcheggi"}
       ],
-      "image": "https://upload.wikimedia.org/wikipedia/commons/0/0c/San_Gimignano_view_2008.jpg",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/5/5e/Torre_Rognosa_in_San_Gimignano_Italy.jpg",
       "apple_maps_url": "https://maps.apple.com/?ll=43.4670,11.0420&q=San%20Gimignano",
       "map_query": "Parcheggio San Gimignano P1"
     },
@@ -253,7 +253,7 @@
         {"title": "Parco Maremma – Info/Visita (offiziell)", "url": "https://parco-maremma.it/visita/informazioni/"},
         {"title": "Parco Maremma – Orari apertura", "url": "https://parco-maremma.it/visita/orari-di-apertura/"}
       ],
-      "image": "https://upload.wikimedia.org/wikipedia/commons/2/24/Parco_della_Maremma_-_Marina_di_Alberese.jpg",
+      "image": "https://upload.wikimedia.org/wikipedia/commons/4/47/Parco_naturale_della_Maremma_spiaggia_di_Principina.jpg",
       "map_query": "Centro Visite Parco della Maremma Alberese"
     }
   ]

--- a/reader.md
+++ b/reader.md
@@ -8,12 +8,13 @@
 ## Data Sources
 - Primary JSON datasets live in `data/*.json` with the bundled fallback defined in `data/static-trips.ts`.
 - Loader utilities (`loadTrips`, `loadItems`) clone data defensively to preserve immutability and maintain O(n) complexity per request.
+- Hero imagery is sourced from authoritative remote hosts (Commons, ticket portals) and cached lazily through `/api/image` so deployments stay lightweight.
 - Apple/Google Maps links are synthesized in `lib/trips.ts`; keep new data aligned with the `Item` interface.
 
 ## Architecture Overview
 - Next.js 15 App Router with a single page composed of server components, styled via Tailwind + custom CSS tokens.
 - Shared UI idioms: `glass-panel` shells, sticky horizontal filters, card hover glow, and accent-forward CTAs.
-- Image proxying handled through `/lib/image-proxy` and `/api/image` to whitelist hosts and supply cached responses.
+- `resolveImageSrc` in `lib/image-proxy.ts` decides whether to serve local assets or proxy remote hosts through `/api/image`, keeping SSRF guards intact.
 
 ## Usage Example
 ```ts


### PR DESCRIPTION
## Summary
- replace every Montescudaio trip photo with a curated remote URL from Wikimedia Commons or Unsplash
- remove the previously bundled image binaries now that assets are fetched and cached post-deploy
- document the remote-image workflow in the README and reader notes

## Testing
- pnpm quality

------
https://chatgpt.com/codex/tasks/task_e_68c972ba79208321b5f99a48a4464e37