### PR TITLE
Shorten navigation chips and document image proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ media libraries (e.g., Wikimedia Commons). Only use hosts listed in
 caches the response on first request. When you need a new host, add it to the
 allow-list and document the license in the dataset comment.
 
+### Remote Image Pipeline
+
+- `resolveImageSrc` normalises every `image` entry and sends remote URLs through
+  `/api/image`, guaranteeing cached, SSRF-safe delivery.
+- The API route validates hosts against `ALLOWED_IMAGE_HOSTS` before proxying
+  and stores results on first request for deterministic renders.
+- To unblock new photo sources, extend the allow-list in
+  `lib/image-proxy.ts` and mention the licence + provenance alongside the data
+  row so audits stay trivial.
+
 ## Usage Example
 
 ```ts

--- a/__tests__/page.test.tsx
+++ b/__tests__/page.test.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
+import type { Item } from '@/lib/trips';
 
 jest.mock('next/image', () => ({
   __esModule: true,
   default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => React.createElement('img', props),
 }));
 
-const mockItems = [
+const mockItems: Item[] = [
   {
     id: 'pisa',
-    name: 'Pisa – Piazza dei Miracoli',
+    name: 'Pisa – Piazza dei Miracoli & Schiefer Turm',
     category: 'Stadt',
     links: [
       { title: 'Tourismus Pisa', url: 'https://www.turismo.pisa.it/' },
@@ -17,8 +18,14 @@ const mockItems = [
   },
   {
     id: 'florence',
-    name: 'Florenz kompakt',
+    name: 'Florenz kompakt – Uffizien & Altstadt stressfrei',
     category: 'Stadt',
+    links: [],
+  },
+  {
+    id: 'lucca_sat_indie',
+    name: 'SA 20.09 – WØM FEST OFF (Indie/Electro) @ Distilleria Indie',
+    category: 'Musik',
     links: [],
   },
 ];
@@ -46,5 +53,22 @@ describe('Page navigation layout', () => {
     const Page = (await import('@/app/page')).default;
     const html = renderToStaticMarkup(React.createElement(Page));
     expect(html).toContain('scroll-mt-40');
+  });
+
+  it('renders shortened navigation labels derived from long titles', async () => {
+    const Page = (await import('@/app/page')).default;
+    const html = renderToStaticMarkup(React.createElement(Page));
+    expect(html).toContain('Pisa – Piazza dei Miracoli');
+    expect(html).toContain('Florenz kompakt – Uffizien');
+    expect(html).toContain('Distilleria Indie – WØM FEST OFF');
+  });
+});
+
+describe('getNavLabel', () => {
+  it('collapses long titles to concise navigation chips', async () => {
+    const { getNavLabel } = await import('@/app/page');
+    expect(getNavLabel(mockItems[0])).toBe('Pisa – Piazza dei Miracoli');
+    expect(getNavLabel(mockItems[1])).toBe('Florenz kompakt – Uffizien');
+    expect(getNavLabel(mockItems[2])).toBe('Distilleria Indie – WØM FEST OFF');
   });
 });

--- a/prompt.md
+++ b/prompt.md
@@ -24,6 +24,8 @@
 - Source trip content via `loadItems()` / `loadTrips()` from `lib/trips.ts`; never bypass caching logic.
 - Highlight key derived stats (count, categories, max drive) in O(n) aggregations only.
 - Guard against empty data by surfacing fallback messaging and ensuring deterministic ordering by popularity.
+- Hero images must resolve through `resolveImageSrc` so `/api/image` proxies and caches approved hosts from
+  `ALLOWED_IMAGE_HOSTS`; document any new source before extending the allow-list.
 
 ## Interactions
 - Keep sticky chip navigation accessible (keyboard focus, ARIA labels on icons as needed).

--- a/status.md
+++ b/status.md
@@ -15,3 +15,5 @@
 ## Decisions
 - Keep chip navigation sticky with current shadow treatment to preserve recognisable brand feel.
 - Prioritize deterministic data loaders over real-time fetches to stay Vercel hobby-tier friendly.
+- Remote image delivery stays behind `/api/image` with `ALLOWED_IMAGE_HOSTS` guarding provenance; onboarding a new host now
+  requires doc updates + licence notes in the dataset.


### PR DESCRIPTION
## Summary
- derive concise navigation chip labels from trip titles so the sticky bar stays compact
- cover the new `getNavLabel` helper with unit tests alongside server markup assertions
- document the remote image proxy pipeline across README, prompt, and status docs

## Testing
- pnpm quality

------
https://chatgpt.com/codex/tasks/task_e_68c99a7aaa30832181eec6cbf759d01d